### PR TITLE
Don't wrap iframe in a div

### DIFF
--- a/vendor/assets/javascripts/tinymce/plugins/media/plugin.js
+++ b/vendor/assets/javascripts/tinymce/plugins/media/plugin.js
@@ -241,7 +241,7 @@ tinymce.PluginManager.add('media', function(editor, url) {
       });
 
       if (data.type == "iframe") {
-        html += '<div class="embed video-embed"><iframe src="' + data.source1 + '" width="' + data.width + '" height="' + data.height + '"></iframe></div>';
+        html += '<iframe class="tinymce-video-embed" src="' + data.source1 + '" width="' + data.width + '" height="' + data.height + '"></iframe>';
       } else if (data.source1mime == "application/x-shockwave-flash") {
         html += '<object data="' + data.source1 + '" width="' + data.width + '" height="' + data.height + '" type="application/x-shockwave-flash">';
 


### PR DESCRIPTION
Changement de stratégie. Au lieu de wrapper dans un div qui brise les ajouts subséquents dans tinymce, je vais uniquement ajouter une classe spécial au iframe et nous ajouterons un style custom pour ce iframe en particulier dans le viewer.