### PR TITLE
Remove bad closing comment tag

### DIFF
--- a/vendor/assets/javascripts/tinymce/skins/crowdbase/skin.min.css
+++ b/vendor/assets/javascripts/tinymce/skins/crowdbase/skin.min.css
@@ -572,9 +572,6 @@ body .mce-abs-layout-item, .mce-abs-end {
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2', endColorstr='#ffcccccc', GradientType=0);
     zoom: 1;
     */
-    border-color: #ccc #ccc #a6a6a6;
-    
-    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);*/
 }
 .mce-btn.mce-disabled, .mce-btn.mce-disabled:hover {
     cursor: default;


### PR DESCRIPTION
Une balise fermante orpheline de commentaire avait été oubliée dans le css, causant un crash lors de la compilation du fichier. On en profite pour retirer les deux instructions `border-color` qui ne donnent pas un beau résultat à l'affichage.